### PR TITLE
bump up Hono version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ const config: VerifyFirebaseAuthConfig = {
 }
 
 // Or you can specify here the extended VerifyFirebaseAuthEnv type.
-const app = new Hono<VerifyFirebaseAuthEnv>()
+const app = new Hono<{ Bindings: VerifyFirebaseAuthEnv }>()
 
 // set middleware
 app.use("*", verifyFirebaseAuth(config));

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "firebase-auth-cloudflare-workers": "^1.0.0",
-    "hono": "^2.0.5"
+    "hono": "^2.1.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^3.14.1",

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -135,7 +135,7 @@ describe("verifyFirebaseAuth middleware", () => {
         },
       ],
     ])("%s", async (_, { headerKey, env, config, wantStatus }) => {
-      const app = new Hono<VerifyFirebaseAuthEnv>();
+      const app = new Hono<{ Bindings: VerifyFirebaseAuthEnv }>();
 
       resetAuth();
 
@@ -167,7 +167,7 @@ describe("verifyFirebaseAuth middleware", () => {
       const getSpy = jest.spyOn(nopKeyStore, "get");
       const putSpy = jest.spyOn(nopKeyStore, "put");
 
-      const app = new Hono<VerifyFirebaseAuthEnv>();
+      const app = new Hono<{ Bindings: VerifyFirebaseAuthEnv }>();
 
       resetAuth();
 
@@ -202,7 +202,7 @@ describe("verifyFirebaseAuth middleware", () => {
       const testingJWT = generateDummyJWT();
 
       const nopKeyStore = new NopKeyStore();
-      const app = new Hono<VerifyFirebaseAuthEnv>();
+      const app = new Hono<{ Bindings: VerifyFirebaseAuthEnv }>();
 
       resetAuth();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3245,10 +3245,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hono@^2.0.5:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-2.0.5.tgz#a40355f5fddb287f631c3953828b834c2775cb45"
-  integrity sha512-Vuwj2Qbk94y6NSTzaMo2eYHLyX0OpKmTONKOhUYUK6Lx6L/IRsDJ37aBY+7wi3oli7Sez792cAuZ5vdSt/Qt+g==
+hono@^2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-2.1.3.tgz#51cc616ffadd5ad279ca3129f1328d77fa180c7d"
+  integrity sha512-+GV1f19Vx4E76+8cYGUJit0pxu1oA2lvUE3ctxf4eg3Ov7OlmldZhdnH5EjLNzbgQOcBo8wZV6izRa5lHa4fmg==
 
 html-escaper@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
Bumped up Hono version to 2.1.3. And fixed the syntax for Cloudflare Workers environment variables. It has been changed since Hono v2.1.0.

```ts
// Before
const app = new Hono<VerifyFirebaseAuthEnv>()

// Current
const app = new Hono<{ Bindings: VerifyFirebaseAuthEnv }>()
```